### PR TITLE
Fixed openCV include for version 4.8.0

### DIFF
--- a/include/camera_calibrator.hpp
+++ b/include/camera_calibrator.hpp
@@ -6,6 +6,7 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <opencv2/opencv.hpp>
+#include <opencv2/calib3d/calib3d_c.h>
 #include <vector>
 
 #include "logging.hpp"

--- a/include/camera_calibrator.hpp
+++ b/include/camera_calibrator.hpp
@@ -6,7 +6,7 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <opencv2/opencv.hpp>
-#include <opencv2/calib3d/calib3d_c.h>
+#include <opencv2/calib3d.hpp>
 #include <vector>
 
 #include "logging.hpp"

--- a/src/camera_calibrator.cpp
+++ b/src/camera_calibrator.cpp
@@ -62,8 +62,15 @@ void CameraCalibrator::get_result(cv::Mat &camera_matrix, cv::Mat &k,
                                   std::vector<cv::Mat> &rvecsMat,
                                   std::vector<cv::Mat> &tvecsMat) {
   double re_error =
-      cv::calibrateCamera(_boards_pts_3d, _imgs_pts, image_size, camera_matrix,
-                          k, rvecsMat, tvecsMat, CV_CALIB_FIX_PRINCIPAL_POINT);
+      cv::calibrateCamera(_boards_pts_3d,
+                          _imgs_pts,
+                          image_size,
+                          camera_matrix,
+                          k,
+                          rvecsMat,
+                          tvecsMat,
+                          cv::CALIB_FIX_PRINCIPAL_POINT);
+
   std::cout << "reprojection is " << re_error << std::endl;
 
   Eigen::Matrix3d camera_intrinsic;


### PR DESCRIPTION
Added missing include, without  which could not find CV_CALIB_FIX_PRNCIPAL_POINT define. Tested with openCV 4.8.0.